### PR TITLE
Restart sonarr after upgrading.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@ apt_update
 
 package 'nzbdrone' do
   action :upgrade
+  notifies :restart, 'service[sonarr]', :delayed
 end
 
 systemd_unit 'sonarr.service' do


### PR DESCRIPTION
Force Sonarr to reload/restart after upgrade to fully upgrade the application.